### PR TITLE
Fix PBE_SLIA primitives, fix all_problem_grammar_pairs macro

### DIFF
--- a/src/data/SyGuS/PBE_SLIA_Track_2019/grammars.jl
+++ b/src/data/SyGuS/PBE_SLIA_Track_2019/grammars.jl
@@ -4,6 +4,8 @@ grammar_11604909 = @cfgrammar begin
 	ntString = ""
 	ntString = " "
 	ntString = "."
+	ntString = "="
+	ntString = "-"
 	ntString = concat_cvc(ntString, ntString)
 	ntString = replace_cvc(ntString, ntString, ntString)
 	ntString = at_cvc(ntString, ntInt)

--- a/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
+++ b/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
@@ -16,7 +16,7 @@ len_cvc(str::String) = length(str)
 
 str_to_int_cvc(str::String) = parse(Int64, str)
 
-indexof_cvc(str::String, substring::String, index::Int) = (n = findfirst(str, substring); n == nothing ? -1 : (n[1] >= index ? -1 : n[1]))
+indexof_cvc(str::String, substring::String, index::Int) = (n = findfirst(substring, str); n == nothing ? -1 : (n[1] >= index ? n[1] : -1))
 
 # Bool typed
 prefixof_cvc(prefix::String, str::String) = startswith(str, prefix)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -134,7 +134,7 @@ function find_corresponding_grammar(problem_name::AbstractString, module_name::M
         return grammar_id
     else
         # Find the default grammar that starts with "grammar_"
-        for (name, value) in names(module_name; all=true)
+        for name in names(module_name; all=true)
             if startswith(string(name), "grammar_")
                 return name
             end


### PR DESCRIPTION
- Branch name is not fitting anymore
- fixed PBE_SLIA primitives, so they work as intended in CVC4/5
- this includes a temporary fix for a PBE_SLIA grammar. Proper re-build of these is still mandatory.