### PR TITLE
Custom interpreter for SLIA

### DIFF
--- a/src/HerbBenchmarks.jl
+++ b/src/HerbBenchmarks.jl
@@ -23,10 +23,12 @@ end
 #include("utils/benchmark_generator.jl")
 include("utils/benchmarks_io.jl")
 include("utils/problem_fetcher.jl")
+include("utils/interpret_generator.jl")
 
 # Include data types
 include("datatypes/problem_grammar_pair.jl")
 include("datatypes/benchmark.jl")
+
 
 export 
     # Data types
@@ -39,7 +41,11 @@ export
     parse_to_julia,
     append_cfgrammar,
     enumerate_problem_files,
-    
+
+    # grammar_tag generators
+    make_interpreter,
+    get_relevant_tags,
+
     # Problem fetcher
     get_all_benchmarks,
     get_benchmark,

--- a/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
+++ b/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
@@ -1,3 +1,4 @@
+using MLStyle
 # CVC5 functions
 
 ## String typed
@@ -31,3 +32,31 @@ leq_cvc(str1::String, str2::String) = cmp(str1, str2) <= 0
 
 isdigit_cvc(str::String) = tryparse(Int, str) !== nothing
 
+"""
+Gets relevant symbol to easily match grammar rules to operations in `interpret` function
+"""
+function get_relevant_tags(grammar::ContextSensitiveGrammar)
+        tags = Dict{Int,Any}()
+        for (ind, r) in pairs(grammar.rules)
+                tags[ind] = if typeof(r) != Expr
+                        r
+                else
+                        @match r.head begin
+                                :block => :OpSeq
+                                :call => r.args[1]
+                                :if => :IF
+                        end
+                end
+        end
+        return tags
+end
+
+function interpret_sygus(prog::AbstractRuleNode, grammar_tags::Dict{Int,Any})
+        r = get_rule(prog)
+        c = get_children(prog)
+        @match grammar_tags[r] begin
+                :concat_cvc => concat_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                # ...
+                _ => grammar_tags[r]
+        end
+end

--- a/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
+++ b/src/data/SyGuS/PBE_SLIA_Track_2019/string_functions.jl
@@ -54,9 +54,26 @@ end
 function interpret_sygus(prog::AbstractRuleNode, grammar_tags::Dict{Int,Any})
         r = get_rule(prog)
         c = get_children(prog)
-        @match grammar_tags[r] begin
-                :concat_cvc => concat_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
-                # ...
+
+        MLStyle.@match grammar_tags[r] begin
+                :concat_cvc     => concat_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                :replace_cvc    => replace_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags), interpret_sygus(c[3], grammar_tags))
+                :at_cvc         => at_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                :int_to_str_cvc => int_to_str_cvc(interpret_sygus(c[1], grammar_tags))
+                :substr_cvc     => substr_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags), interpret_sygus(c[3], grammar_tags))
+                :len_cvc        => len_cvc(interpret_sygus(c[1], grammar_tags))
+                :str_to_int_cvc => str_to_int_cvc(interpret_sygus(c[1], grammar_tags))
+                :indexof_cvc    => indexof_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags), interpret_sygus(c[3], grammar_tags))
+                :prefixof_cvc   => prefixof_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                :suffixof_cvc   => suffixof_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                :contains_cvc   => contains_cvc(interpret_sygus(c[1], grammar_tags), interpret_sygus(c[2], grammar_tags))
+                
+                :+              => interpret_sygus(c[1], grammar_tags) + interpret_sygus(c[2], grammar_tags)
+                :-              => interpret_sygus(c[1], grammar_tags) - interpret_sygus(c[2], grammar_tags)
+                :(==)           => interpret_sygus(c[1], grammar_tags) == interpret_sygus(c[2], grammar_tags)
+
+                :IF             => interpret_sygus(c[1], grammar_tags) ? interpret_sygus(c[2], grammar_tags) : interpret_sygus(c[3], grammar_tags)
+                
                 _ => grammar_tags[r]
         end
 end

--- a/src/utils/interpret_generator.jl
+++ b/src/utils/interpret_generator.jl
@@ -1,0 +1,65 @@
+using MLStyle
+
+function get_relevant_tags(grammar::AbstractGrammar)
+    tags = Dict{Int,Any}()
+    for (ind, r) in pairs(grammar.rules)
+        tags[ind] = if r isa Expr
+            @match r.head begin
+                :block => :OpSeq
+                :call  => r.args[1]  # operator symbol
+                :if    => :IF
+                _      => r.head
+            end
+        else
+            r
+        end
+    end
+    return tags
+end
+
+"""
+    build_match_cases(grammar::AbstractGrammar)
+
+Generate `Expr` cases for MLStyle.@match based on the grammar.
+"""
+function build_match_cases(grammar::ContextSensitiveGrammar)
+    tags = get_relevant_tags(grammar)
+    cases = []
+
+    for (ind, r) in pairs(grammar.rules)
+        tag = tags[ind]
+        if r isa Expr && r.head == :call
+            fname = r.args[1]
+            nargs = length(r.args) - 1
+            args = [:(interpret_sygus(c[$i], grammar_tags)) for i in 1:nargs]
+            # push!(cases, :($tag => $fname($(args...))))
+            push!(cases, :( $(QuoteNode(tag)) => $fname($(args...)) ))
+        elseif r isa Expr && r.head == :if
+            push!(cases, :( :IF => interpret_sygus(c[1], grammar_tags) ? interpret_sygus(c[2], grammar_tags) : interpret_sygus(c[3], grammar_tags) ))
+        elseif tag isa Symbol && tag in (:+, :-, :(==))
+            lhs = :(interpret_sygus(c[1], grammar_tags))
+            rhs = :(interpret_sygus(c[2], grammar_tags))
+            op_expr = Expr(:call, tag, lhs, rhs)
+            push!(cases, :($tag => $op_expr))
+        end
+    end
+
+    push!(cases, :( _ => grammar_tags[r] ))
+
+    return cases
+end
+
+
+function make_interpreter(grammar::AbstractGrammar)
+    cases = build_match_cases(grammar)
+    quote
+        function interpret(prog::AbstractRuleNode, grammar_tags::Dict{Int,Any})
+            r = get_rule(prog)
+            c = get_children(prog)
+
+            MLStyle.@match grammar_tags[r] begin
+                $(cases...)
+            end
+        end
+    end
+end

--- a/src/utils/interpret_generator.jl
+++ b/src/utils/interpret_generator.jl
@@ -31,14 +31,14 @@ function build_match_cases(grammar::ContextSensitiveGrammar)
         if r isa Expr && r.head == :call
             fname = r.args[1]
             nargs = length(r.args) - 1
-            args = [:(interpret_sygus(c[$i], grammar_tags)) for i in 1:nargs]
+            args = [:(interpret(c[$i], grammar_tags)) for i in 1:nargs]
             # push!(cases, :($tag => $fname($(args...))))
             push!(cases, :( $(QuoteNode(tag)) => $fname($(args...)) ))
         elseif r isa Expr && r.head == :if
-            push!(cases, :( :IF => interpret_sygus(c[1], grammar_tags) ? interpret_sygus(c[2], grammar_tags) : interpret_sygus(c[3], grammar_tags) ))
+            push!(cases, :( :IF => interpret(c[1], grammar_tags) ? interpret(c[2], grammar_tags) : interpret(c[3], grammar_tags) ))
         elseif tag isa Symbol && tag in (:+, :-, :(==))
-            lhs = :(interpret_sygus(c[1], grammar_tags))
-            rhs = :(interpret_sygus(c[2], grammar_tags))
+            lhs = :(interpret(c[1], grammar_tags))
+            rhs = :(interpret(c[2], grammar_tags))
             op_expr = Expr(:call, tag, lhs, rhs)
             push!(cases, :($tag => $op_expr))
         end


### PR DESCRIPTION
As noted yesterday in @matteo-meluzzi's presentation, we are missing a custom interpreter for SLIA here. This is the beginning of an implementation that matches the robots and string transformation benchmarks.

Taking into account the fact that the default interpreter takes an expression as input and not a `RuleNode` directly, this speeds up the interpret step by an order of magnitude.

```julia
[...]

julia> r = @rulenode 6{3,4};

julia> g = HerbBenchmarks.PBE_SLIA_Track_2019.grammar_split_text_string_at_specific_character;

julia> t = PBE_SLIA_Track_2019.get_relevant_tags(g);

julia> @btime interpret(rulenode2expr((@rulenode 6{3,4}), g))
  936.036 ns (30 allocations: 1.70 KiB)
" "

julia> @btime PBE_SLIA_Track_2019.interpret_sygus(r, t)
  65.713 ns (1 allocation: 24 bytes)
" "

```

I believe all that's left to do here is fill in the other relevant functions in the same pattern as `concat_cvc`. @matteo-meluzzi if this is useful to you, maybe you can finish what I've started here? It should improve the runtime of the first step or two of your method by _a lot_.