### PR TITLE
Add ARC_AGI_2 data; update README

### DIFF
--- a/src/data/ARC_AGI_2/ARC_AGI_2.jl
+++ b/src/data/ARC_AGI_2/ARC_AGI_2.jl
@@ -1,4 +1,37 @@
 module ARC_AGI_2
 
+using HerbCore
+using HerbSpecification
+using HerbGrammar
+
+include("data.jl")
+# include("grammar.jl")
+
+"""
+    training_problems()
+
+Return the ARC-AGI-2 public training problems.
+"""
+training_problems() = ARC_AGI2_TRAINING
+
+"""
+    evaluation_problems()
+
+Return the ARC-AGI-2 public evaluation problems.
+"""
+evaluation_problems() = ARC_AGI2_EVALUATION
+
+"""
+    all_problems()
+
+Return all public ARC-AGI-2 problems.
+"""
+all_problems() = ARC_AGI2_ALL
+
+
+export 
+    training_problems
+    evaluation_problems
+    all_problems
 
 end # module ARC_AGI_2

--- a/src/data/ARC_AGI_2/README.md
+++ b/src/data/ARC_AGI_2/README.md
@@ -1,5 +1,36 @@
-# Abstraction and Reasoning Corpus (ARC) 2019
+# Abstraction and Reasoning Corpus (ARC) Challenge 2 
 
-TODO
+This module provides the public ARC-AGI-2 benchmark in the `Herb.jl` format.
+
+## What is ARC-AGI-2?
+
+ARC-AGI-2 is a benchmark for abstraction and reasoning. Each task consists of several example input/output grid pairs and one or more test inputs. The goal is to infer the transformation and produce the correct output grid(s).
+
+## Dataset contents
+
+The public ARC-AGI-2 dataset contains:
+
+- **1,000 training tasks**
+- **120 evaluation tasks**
+
+In this package, both splits are translated into our `Problem` format.
+
+## Task format
+
+Each grid is a rectangular matrix of integers from `0` to `9`.
+
+## Usage
+
+Load the module and access the translated problems:
+
+```julia
+using HerbBenchmarks.ARC_AGI_2
+
+training_problems()
+evaluation_problems()
+all_problems()
+```
+
+returns all training, evaluation, and all problems respectively.
 
 


### PR DESCRIPTION
- parsed all `ARC_AGI_2` data to  Herb.jl format
- added some functions to load training, evaluation and all data.
- added a (semi-)useful readme.

Still missing: 
- grammars, but I think we can just re-use the existing grammars.